### PR TITLE
Correction prof

### DIFF
--- a/src/main/java/com/imt/framework/web/delivecrous/JerseyConfig.java
+++ b/src/main/java/com/imt/framework/web/delivecrous/JerseyConfig.java
@@ -1,6 +1,6 @@
 package com.imt.framework.web.delivecrous;
 
-import com.project.cors.CorsFilter;
+import com.imt.framework.web.delivecrous.cors.CorsFilter;
 import com.imt.framework.web.delivecrous.resources.DishResource;
 import jakarta.ws.rs.ApplicationPath;
 import org.glassfish.jersey.server.ResourceConfig;

--- a/src/main/java/com/imt/framework/web/delivecrous/cors/CorsFilter.java
+++ b/src/main/java/com/imt/framework/web/delivecrous/cors/CorsFilter.java
@@ -1,4 +1,4 @@
-package com.project.cors;
+package com.imt.framework.web.delivecrous.cors;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;

--- a/src/main/java/com/imt/framework/web/delivecrous/repositories/DishRepository.java
+++ b/src/main/java/com/imt/framework/web/delivecrous/repositories/DishRepository.java
@@ -13,8 +13,8 @@ public interface DishRepository extends JpaRepository<Dish, Long> {  //Long pour
     @Query("select d from Dish d where d.price < :maxPrice")  // : -> pour mettre un paramètre/variable
     List<Dish> getDishsWithMaxPriceFilter(@Param("maxPrice") Double maxPrice);
 
-    /*@Query("SELECT d FROM Dish d WHERE ARRAY_CONTAINS(d.categories, :selectedCategory)")
-    List<Dish> getDishsWithSelectedCategory(@Param("selectedCategory") String selectedCategory);*/
+    @Query(value = "SELECT d FROM Dish d WHERE ARRAY_CONTAINS(d.categories, :selectedCategory)", nativeQuery = true)
+    List<Dish> getDishsWithSelectedCategory(@Param("selectedCategory") String selectedCategory);
 
     /*@Query("SELECT * FROM DISH WHERE 'selectedAllergens' = ANY(ALLERGEN_LIST)")
     List<Dish> getDishsWithSelectedAllergens(@Param("selectedAllergens") List<String> selectedAllergens);*/


### PR DESCRIPTION
Bonjour à vous,

Je fais cette PR (pull request) pour corriger le problème de création de Bean lié à la requête sur le filtre de catégorie. 

J'ai ajouté une propriété nativeQuery = true au niveau de l'annotation Query. 
Quand cette propriété n'est pas mise, JPQL (JPA SQL) utilise sa propre syntaxe pour exécuter les requêtes. Le fait de préciser que c'est une requête native permet à JPQL d'ignorer sa syntaxe pour lancer la requête telle quelle. 

Mon hypothèse est que JPQL ne connait pas le mot clé ARRAY_CONTAINS ou il en a une définition particulière.